### PR TITLE
[refactoring] HttpResponse, RequestHandler 리팩토링

### DIFF
--- a/src/main/java/webserver/HttpResponse.java
+++ b/src/main/java/webserver/HttpResponse.java
@@ -29,6 +29,14 @@ public class HttpResponse {
     }
 
     public void forward(String resource) {
+        if (resource.endsWith(".css")) {
+            setContentType("text/css");
+        } else if (resource.endsWith(".js")) {
+            setContentType("application/javascript");
+        } else {
+            setContentType("text/html;charset=utf-8");
+        }
+
         forwardBody(readFile(resource));
     }
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -26,18 +26,18 @@ public class RequestHandler extends Thread {
             final HttpResponse httpResponse = HttpResponse.of(out, "./webapp");
 
             final Controller controller = RequestMapping.findController(httpRequest.getPath());
+
             if (controller == null) {
-                if (httpRequest.getHeader("Accept").contains("text/css")) {
-                    httpResponse.setContentType("text/css;charset=utf-8");
-                } else {
-                    httpResponse.setContentType("text/html;charset=utf-8");
-                }
-                httpResponse.forward(httpRequest.getPath());
+                httpResponse.forward(getDefaultPath(httpRequest.getPath()));
             } else {
                 controller.service(httpRequest, httpResponse);
             }
         } catch (IOException e) {
             log.error(e.getMessage());
         }
+    }
+
+    private String getDefaultPath(String path) {
+        return "/".equals(path) ? "/index.html" : path;
     }
 }

--- a/src/test/java/webserver/HttpResponseTest.java
+++ b/src/test/java/webserver/HttpResponseTest.java
@@ -24,8 +24,9 @@ public class HttpResponseTest {
         final String[] results = out.toString().split("\r\n");
         assertThat(results[0]).isEqualTo("HTTP/1.1 200 OK ");
         assertThat(results[1]).isEqualTo("Content-Length: 13 ");
-        assertThat(results[2]).isEqualTo("");
-        assertThat(results[3]).isEqualTo("<h1>test</h1>");
+        assertThat(results[2]).isEqualTo("Content-Type: text/html;charset=utf-8 ");
+        assertThat(results[3]).isEqualTo("");
+        assertThat(results[4]).isEqualTo("<h1>test</h1>");
     }
 
     @Test


### PR DESCRIPTION
- content type 지정을 HttpResponse 클래스로 이전
- 요청 경로가 "/"이면 기본 경로 "/index.html"로 처리